### PR TITLE
Refactoring with allocateload

### DIFF
--- a/src/MathOptInterfaceSCS.jl
+++ b/src/MathOptInterfaceSCS.jl
@@ -10,6 +10,10 @@ const VI = MOI.VariableIndex
 using MathOptInterfaceUtilities
 const MOIU = MathOptInterfaceUtilities
 
+const SF = Union{MOI.SingleVariable, MOI.ScalarAffineFunction{Float64}, MOI.VectorOfVariables, MOI.VectorAffineFunction{Float64}}
+const SS = Union{MOI.EqualTo{Float64}, MOI.GreaterThan{Float64}, MOI.LessThan{Float64}, MOI.Zeros, MOI.Nonnegatives, MOI.Nonpositives, MOI.SecondOrderCone, MOI.ExponentialCone, MOI.PositiveSemidefiniteConeTriangle}
+
+
 MOIU.@instance SCSInstanceData () (EqualTo, GreaterThan, LessThan) (Zeros, Nonnegatives, Nonpositives, SecondOrderCone, ExponentialCone, PositiveSemidefiniteConeTriangle) () (SingleVariable,) (ScalarAffineFunction,) (VectorOfVariables,) (VectorAffineFunction,)
 
 using SCS
@@ -20,10 +24,11 @@ mutable struct SCSSolverInstance <: MOI.AbstractSolverInstance
     instancedata::SCSInstanceData{Float64} # Will be removed when
     idxmap::MOIU.IndexMap                  # InstanceManager is ready
     cone::Cone
+    maxsense::Bool
     data::Union{Void, Data} # only non-Void between MOI.copy! and MOI.optimize!
     sol::Solution
     function SCSSolverInstance()
-        new(SCSInstanceData{Float64}(), MOIU.IndexMap(), Cone(), nothing, Solution())
+        new(SCSInstanceData{Float64}(), MOIU.IndexMap(), Cone(), false, nothing, Solution())
     end
 end
 

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -42,10 +42,7 @@ function MOI.get(instance::SCSSolverInstance, ::MOI.PrimalStatus)
         MOI.InfeasiblePoint
     end
 end
-function MOI.canget(instance::SCSSolverInstance, ::Union{MOI.VariablePrimal, MOI.ConstraintPrimal}, r::MOI.Index)
-    instance.sol.ret_val in (-6, -3, -1, 1, 2)
-end
-function MOI.canget(instance::SCSSolverInstance, ::Union{MOI.VariablePrimal, MOI.ConstraintPrimal}, r::Vector{<:MOI.Index})
+function MOI.canget(instance::SCSSolverInstance, ::Union{MOI.VariablePrimal, MOI.ConstraintPrimal}, ::Type{<:MOI.Index})
     instance.sol.ret_val in (-6, -3, -1, 1, 2)
 end
 function MOI.get(instance::SCSSolverInstance, ::MOI.VariablePrimal, vi::VI)

--- a/src/attributes.jl
+++ b/src/attributes.jl
@@ -74,7 +74,7 @@ function MOI.get(instance::SCSSolverInstance, ::MOI.DualStatus)
         MOI.InfeasiblePoint
     end
 end
-function MOI.canget(instance::SCSSolverInstance, ::MOI.ConstraintDual, ::CI)
+function MOI.canget(instance::SCSSolverInstance, ::MOI.ConstraintDual, ::Type{<:CI})
     instance.sol.ret_val in (-7, -3, -2, 1, 2)
 end
 function MOI.get(instance::SCSSolverInstance, ::MOI.ConstraintDual, ci::CI{<:MOI.AbstractFunction, S}) where S <: MOI.AbstractSet

--- a/src/data.jl
+++ b/src/data.jl
@@ -7,10 +7,19 @@ MOI.delete!(instance::SCSSolverInstance, r::MOI.Index) = MOI.delete!(instance.in
 for f in (:canget, :canset, :set!, :get, :get!)
     @eval begin
         MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute) = MOI.$f(instance.instancedata, attr)
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, ref::MOI.Index) = MOI.$f(instance.instancedata, attr, ref)
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, refs::Vector{<:MOI.Index}) = MOI.$f(instance.instancedata, attr, refs)
         # Objective function
         MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, arg::Union{MOI.OptimizationSense, MOI.AbstractScalarFunction}) = MOI.$f(instance.instancedata, attr, arg)
+    end
+end
+for f in (:canget, :canset)
+    @eval begin
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, index::Type{<:MOI.Index}) = MOI.$f(instance.instancedata, attr, index)
+    end
+end
+for f in (:set!, :get, :get!)
+    @eval begin
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, index::MOI.Index) = MOI.$f(instance.instancedata, attr, index)
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, indices::Vector{<:MOI.Index}) = MOI.$f(instance.instancedata, attr, indices)
     end
 end
 

--- a/src/data.jl
+++ b/src/data.jl
@@ -1,29 +1,29 @@
 # References
-MOI.candelete(instance::SCSSolverInstance, r::MOI.Index) = MOI.candelete(instance.data, r)
-MOI.isvalid(instance::SCSSolverInstance, r::MOI.Index) = MOI.isvalid(instance.data, r)
-MOI.delete!(instance::SCSSolverInstance, r::MOI.Index) = MOI.delete!(instance.data, r)
+MOI.candelete(instance::SCSSolverInstance, r::MOI.Index) = MOI.candelete(instance.instancedata, r)
+MOI.isvalid(instance::SCSSolverInstance, r::MOI.Index) = MOI.isvalid(instance.instancedata, r)
+MOI.delete!(instance::SCSSolverInstance, r::MOI.Index) = MOI.delete!(instance.instancedata, r)
 
 # Attributes
 for f in (:canget, :canset, :set!, :get, :get!)
     @eval begin
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute) = MOI.$f(instance.data, attr)
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, ref::MOI.Index) = MOI.$f(instance.data, attr, ref)
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, refs::Vector{<:MOI.Index}) = MOI.$f(instance.data, attr, refs)
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute) = MOI.$f(instance.instancedata, attr)
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, ref::MOI.Index) = MOI.$f(instance.instancedata, attr, ref)
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, refs::Vector{<:MOI.Index}) = MOI.$f(instance.instancedata, attr, refs)
         # Objective function
-        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, arg::Union{MOI.OptimizationSense, MOI.AbstractScalarFunction}) = MOI.$f(instance.data, attr, arg)
+        MOI.$f(instance::SCSSolverInstance, attr::MOI.AnyAttribute, arg::Union{MOI.OptimizationSense, MOI.AbstractScalarFunction}) = MOI.$f(instance.instancedata, attr, arg)
     end
 end
 
 # Constraints
-MOI.canaddconstraint(instance::SCSSolverInstance, f::MOI.AbstractFunction, s::MOI.AbstractSet) = MOI.canaddconstraint(instance.data, f, s)
-MOI.addconstraint!(instance::SCSSolverInstance, f::MOI.AbstractFunction, s::MOI.AbstractSet) = MOI.addconstraint!(instance.data, f, s)
-MOI.canmodifyconstraint(instance::SCSSolverInstance, ci::CI, change) = MOI.canmodifyconstraint(instance.data, ci, change)
-MOI.modifyconstraint!(instance::SCSSolverInstance, ci::CI, change) = MOI.modifyconstraint!(instance.data, ci, change)
+MOI.canaddconstraint(instance::SCSSolverInstance, f::MOI.AbstractFunction, s::MOI.AbstractSet) = MOI.canaddconstraint(instance.instancedata, f, s)
+MOI.addconstraint!(instance::SCSSolverInstance, f::MOI.AbstractFunction, s::MOI.AbstractSet) = MOI.addconstraint!(instance.instancedata, f, s)
+MOI.canmodifyconstraint(instance::SCSSolverInstance, ci::CI, change) = MOI.canmodifyconstraint(instance.instancedata, ci, change)
+MOI.modifyconstraint!(instance::SCSSolverInstance, ci::CI, change) = MOI.modifyconstraint!(instance.instancedata, ci, change)
 
 # Objective
-MOI.canmodifyobjective(instance::SCSSolverInstance, change::MOI.AbstractFunctionModification) = MOI.canmodifyobjective(instance.data, change)
-MOI.modifyobjective!(instance::SCSSolverInstance, change::MOI.AbstractFunctionModification) = MOI.modifyobjective!(instance.data, change)
+MOI.canmodifyobjective(instance::SCSSolverInstance, change::MOI.AbstractFunctionModification) = MOI.canmodifyobjective(instance.instancedata, change)
+MOI.modifyobjective!(instance::SCSSolverInstance, change::MOI.AbstractFunctionModification) = MOI.modifyobjective!(instance.instancedata, change)
 
 # Variables
-MOI.addvariable!(instance::SCSSolverInstance) = MOI.addvariable!(instance.data)
-MOI.addvariables!(instance::SCSSolverInstance, n) = MOI.addvariables!(instance.data, n)
+MOI.addvariable!(instance::SCSSolverInstance) = MOI.addvariable!(instance.instancedata)
+MOI.addvariables!(instance::SCSSolverInstance, n) = MOI.addvariables!(instance.instancedata, n)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -187,8 +187,8 @@ end
 
 function MOI.optimize!(instance::SCSSolverInstance)
     res = MOI.copy!(instance, instance.instancedata)
-    @assert res.status = MOI.CopySuccess
-    instance.idxmap = res.idxmap
+    @assert res.status == MOI.CopySuccess
+    instance.idxmap = res.indexmap
     cone = instance.cone
     m = instance.data.m
     n = instance.data.n

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,43 @@
+struct Solution
+    ret_val::Int
+    primal::Vector{Float64}
+    dual::Vector{Float64}
+    slack::Vector{Float64}
+    objval::Float64
+end
+Solution() = Solution(0, # SCS_UNFINISHED
+                      Float64[], Float64[], Float64[], NaN)
+
+mutable struct Data
+    m::Int
+    n::Int
+    I::Vector{Int}
+    J::Vector{Int}
+    V::Vector{Float64}
+    b::Vector{Float64}
+    objconstant::Float64
+    maxsense::Bool
+    c::Vector{Float64}
+end
+
+mutable struct Cone
+    f::Int # number of linear equality constraints
+    l::Int # length of LP cone
+    q::Int # length of SOC cone
+    qa::Vector{Int} # array of second-order cone constraints
+    s::Int # length of SD cone
+    sa::Vector{Int} # array of semi-definite constraints
+    ep::Int # number of primal exponential cone triples
+    ed::Int # number of dual exponential cone triples
+    p::Vector{Float64} # array of power cone params
+    setconstant::Dict{Int, Float64} # For the constant of EqualTo, LessThan and GreaterThan
+    nrows::Dict{Int, Int} # The number of rows of each vector sets
+    function Cone()
+        new(0, 0,
+            0, Int[],
+            0, Int[],
+            0, 0, Float64[],
+            Dict{Int, Float64}(),
+            Dict{Int, UnitRange{Int}}())
+    end
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -16,7 +16,6 @@ mutable struct Data
     V::Vector{Float64}
     b::Vector{Float64}
     objconstant::Float64
-    maxsense::Bool
     c::Vector{Float64}
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,8 @@ const MOIT = MathOptInterfaceTests
 
 const solver = () -> SCSInstance()
 # linear9test needs 1e-3 with SCS < 2.0 and 5e-1 with SCS 2.0
-const config = MOIT.TestConfig(1e-5, 1e-5, true, true, true, true)
+# linear2test needs 1e-4
+const config = MOIT.TestConfig(1e-4, 1e-4, true, true, true, true)
 
 @testset "Continuous linear problems" begin
     # AlmostSuccess for linear9 with SCS 2


### PR DESCRIPTION
Prepares the removal of the internal MOIU instance as it will be managed by an InstanceManager instead.
The variable and constraint indices now directly correspond to the internal indices of SCS.
Closes #2 